### PR TITLE
Make ResponseWriter compatible with http.ResponseWriter

### DIFF
--- a/rest/response.go
+++ b/rest/response.go
@@ -26,6 +26,9 @@ type ResponseWriter interface {
 	// middlewares.
 	EncodeJson(v interface{}) ([]byte, error)
 
+	// Identical to the http.ResponseWriter interface
+	Write([]byte) (int, error)
+
 	// Similar to the http.ResponseWriter interface, with additional JSON related
 	// headers set.
 	WriteHeader(int)

--- a/rest/response_test.go
+++ b/rest/response_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/ant0ine/go-json-rest/rest/test"
@@ -65,4 +66,12 @@ func TestNotFoundResponse(t *testing.T) {
 	recorded.CodeIs(404)
 	recorded.ContentTypeIsJson()
 	recorded.BodyIs("{\"Error\":\"Resource not found\"}")
+}
+
+func TestResponseWriterCanBeUsedAsHttpResponseWriter(t *testing.T) {
+	var resp ResponseWriter = &responseWriter{}
+	var httpResp http.ResponseWriter = resp
+	if httpResp == nil {
+		t.Error("ResponseWriter was the expected to be compatible with http.ResponseWriter")
+	}
 }


### PR DESCRIPTION
Current ResponseWriter interface is not compatible with http.ResponseWriter, this change will make them compatible.